### PR TITLE
4.2.0 compatibility

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -4,9 +4,9 @@ source 'https://github.com/CocoaPods/Specs.git'
 use_frameworks!
 
 target 'verifai-example' do
-    pod 'Verifai', '~> 4.1.0'
-    pod 'VerifaiNFC', '~> 4.1.0'
-    pod 'VerifaiLiveness', '~> 4.1.0'
-    pod 'VerifaiManualDataCrosscheck', '~> 4.1.0'
-    pod 'VerifaiManualSecurityFeatureCheck', '~> 4.1.0'
+    pod 'Verifai', '~> 4.2.0'
+    pod 'VerifaiNFC', '~> 4.2.0'
+    pod 'VerifaiLiveness', '~> 4.2.0'
+    pod 'VerifaiManualDataCrosscheck', '~> 4.2.0'
+    pod 'VerifaiManualSecurityFeatureCheck', '~> 4.2.0'
 end

--- a/verifai-example/ChecksViewController.swift
+++ b/verifai-example/ChecksViewController.swift
@@ -56,7 +56,10 @@ class ChecksViewController: UIViewController {
         }
         // Start the NFC component
         do {
-            try VerifaiNFC.start(over: self, documentData: result, retrieveImage: true) { nfcScanResult in
+            try VerifaiNFC.start(over: self,
+                                 documentData: result,
+                                 retrieveImage: true,
+                                 instructionScreenConfiguration: nil) { nfcScanResult in
                 switch nfcScanResult {
                 case .failure(let error):
                     print("Error: \(error)")


### PR DESCRIPTION
## 4.2.0
* Document chooser has been redesigned from the ground up to be more intuitive and to make the differences between document more obvious
* Improved the way we determine which document is being scanned which allows us to skip the document chooser more often
* The SDK has started transition to a new instruction screen system which allows our customers to show either video and text, text only or even a url in several steps throughout the app. For more information about this check out the documentation topic about it here: https://docs.verifai.com/mobile-sdk/ios-sdk-latest.html#instruction-screen-setup
* Deprecated `showInstructionScreens` boolean in favour of a `showInstructionScreens` inside the `VerifaiInstructionScreenConfiguration`
* Copy improvement to default instruction strings and other copy throughout the SDK to make things clearer

* Updated podfile
* Solved ambiguous function error by defining which one I was using.