### PR TITLE
Updated SDK and some code examples

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -4,9 +4,9 @@ source 'https://github.com/CocoaPods/Specs.git'
 use_frameworks!
 
 target 'verifai-example' do
-    pod 'Verifai', '~> 4.2.0'
-    pod 'VerifaiNFC', '~> 4.2.0'
-    pod 'VerifaiLiveness', '~> 4.2.0'
-    pod 'VerifaiManualDataCrosscheck', '~> 4.2.0'
-    pod 'VerifaiManualSecurityFeatureCheck', '~> 4.2.0'
+    pod 'Verifai', '~> 4.3.0'
+    pod 'VerifaiNFC', '~> 4.3.0'
+    pod 'VerifaiLiveness', '~> 4.3.0'
+    pod 'VerifaiManualDataCrosscheck', '~> 4.3.0'
+    pod 'VerifaiManualSecurityFeatureCheck', '~> 4.3.0'
 end

--- a/verifai-example/DocumentDetailsTableViewController.swift
+++ b/verifai-example/DocumentDetailsTableViewController.swift
@@ -31,7 +31,7 @@ class DocumentDetailsTableViewController: UITableViewController {
         super.viewDidLoad()
         
         // Assign all data that was detected to the text fields
-        documentTypeLabel.text = result?.idModel?.type
+        documentTypeLabel.text = result?.mrzData?.documentType
         countryCodeLabel.text = result?.mrzData?.countryCode
         lastNameLabel.text = result?.mrzData?.surname
         firstNameLabel.text = result?.mrzData?.givenNames

--- a/verifai-example/MainViewController.swift
+++ b/verifai-example/MainViewController.swift
@@ -34,13 +34,29 @@ class MainViewController: UIViewController {
         }
         
         // Start configuring Verifai
-        // We have to pass our bundle identifier along with the license key to activate Verifai
+        // Setup the licence
         switch VerifaiCommons.setLicence(licenceString) {
             case .success(_):
                 print("Successfully configured Verifai")
             case .failure(let error):
                 print("🚫 Licence error: \(error)")
         }
+        // You can customise configuration items like this
+        let configuration = VerifaiConfiguration(enableAutomatic: false,
+                                                 requireDocumentCopy: true,
+                                                 requireCroppedImage: false,
+                                                 enablePostCropping: true,
+                                                 enableManual: true,
+                                                 enableAutoUpdate: true,
+                                                 requireMRZContents: true,
+                                                 readMRZContents: true,
+                                                 requireNFCWhenAvailable: true,
+                                                 validators: [])
+        // Instruction screen configuration
+        configuration.instructionScreenConfiguration =
+            try! VerifaiInstructionScreenConfiguration(showInstructionScreens: true,
+                                                       instructionScreens: [:])
+        try? Verifai.configure(with: configuration)
     }
     
     // MARK: - Verifai interaction


### PR DESCRIPTION
## 4.3.0
* Support for scanning new NL documents with BSN in a QR code on the back (introduced August 1)
* Support for scanning barcodes in documents. Currently supports: qr, code39, code128 and pdf417 symbologies
* Fixed bug where user had to tap on the first document in the new document chooser before it was selected
* Breaking change: If you make your own VerifaiResult objects you’ll have to add a `documentBarcodes` value to your initialiser, this value can be nil